### PR TITLE
Do not mutate original geojson object

### DIFF
--- a/index.js
+++ b/index.js
@@ -31,40 +31,48 @@
       
       switch (obj.type) {
         case "Point":
-          obj.coordinates = point(obj.coordinates);
-          return obj;
+          return Object.assign({}, obj, {
+            coordinates: point(obj.coordinates)
+          });
         case "LineString":
         case "MultiPoint":
-          obj.coordinates = multi(obj.coordinates);
-          return obj;
+          return Object.assign({}, obj, {
+            coordinates: multi(obj.coordinates)
+          });
         case "Polygon":
         case "MultiLineString":
-          obj.coordinates = poly(obj.coordinates);
-          return obj;
+          return Object.assign({}, obj, {
+            coordinates: poly(obj.coordinates)
+          });
         case "MultiPolygon":
-          obj.coordinates = multiPoly(obj.coordinates);
-          return obj;
+          return Object.assign({}, obj, {
+            coordinates: multiPoly(obj.coordinates)
+          });
         case "GeometryCollection":
-          obj.geometries = obj.geometries.map(geometry);
-          return obj;
+          return Object.assign({}, obj, {
+            geometries: obj.geometries.map(geometry)
+          });
         default :
           return {};
       }
     }
 
     function feature(obj) {
-      obj.geometry = geometry(obj.geometry);
-      return obj
+      return Object.assign({}, obj, {
+        geometry: geometry(obj.geometry)
+      });
     }
 
     function featureCollection(f) {
-      f.features = f.features.map(feature);
-      return f;
+      return Object.assign({}, f, {
+        features: f.features.map(feature)
+      });
     }
 
     function geometryCollection(g) {
-      g.geometries = g.geometries.map(geometry);
-      return g;
+      return Object.assign({}, g, {
+        geometries: g.geometries.map(geometry)
+      });
     }
 
     if (!t) {

--- a/test/test.js
+++ b/test/test.js
@@ -217,3 +217,12 @@ describe("null Feature geometry", () => {
     }
   });
 });
+
+describe("mutate", () => {
+  it("should not mutate the original object", (done) => {
+    var original = Object.assign({}, tg.point);
+    var parsed = gp(tg.point, 3);
+    assert.deepEqual(original, tg.point);
+    done();
+  });
+});


### PR DESCRIPTION
Thanks for this lib!

This is just a small change to make `parse` a pure function. It won't mutate the original geojson object.